### PR TITLE
Implement points for a correct quiz answer

### DIFF
--- a/commands/general/givexp.go
+++ b/commands/general/givexp.go
@@ -45,74 +45,33 @@ func handleXpAdjustmentCommand(s *discordgo.Session, i *discordgo.InteractionCre
 		delta = -xpAmount
 	}
 	controller := &controllers.LeaderboardController{}
-	userData, err := controller.FindUser(targetUser.ID, i.GuildID)
-	userExists := err == nil
+	if remove {
+		_, found, err := controller.FindUserStats(targetUser.ID, i.GuildID)
+		if err != nil {
+			sentry.CaptureException(err)
+			editXpAdjustmentError(s, i, "XP Update Failed", "I couldn't fetch leaderboard data right now. Try again later.")
+			return
+		}
 
-	if err != nil && !leaderboardUserNotFound(err) {
+		if !found {
+			editXpAdjustmentWarning(
+				s,
+				i,
+				"No XP Removed",
+				fmt.Sprintf("<@%s> does not have leaderboard data yet, so there is no XP to remove.", targetUser.ID),
+			)
+			return
+		}
+	}
+
+	change, err := leveling.AwardXp(s, controller, i.GuildID, targetUser.ID, delta)
+	if err != nil {
 		sentry.CaptureException(err)
-		editXpAdjustmentError(s, i, "XP Update Failed", "I couldn't fetch leaderboard data right now. Try again later.")
+		editXpAdjustmentError(s, i, "XP Update Failed", "I couldn't update leaderboard data right now. Try again later.")
 		return
 	}
 
-	if !userExists && remove {
-		editXpAdjustmentWarning(
-			s,
-			i,
-			"No XP Removed",
-			fmt.Sprintf("<@%s> does not have leaderboard data yet, so there is no XP to remove.", targetUser.ID),
-		)
-		return
-	}
-
-	stats := &leaderboardStats{}
-	if userExists {
-		stats, err = parseLeaderboardStats(userData)
-		if err != nil {
-			sentry.CaptureException(err)
-			editXpAdjustmentError(s, i, "XP Update Failed", "Leaderboard data for that member could not be read.")
-			return
-		}
-	}
-
-	change := leveling.ApplyXpDelta(stats.Level, stats.CurrentXp, stats.TotalXp, delta)
-
-	if !userExists {
-		createErr := controller.CreateUserRecord(controllers.UserCreate{
-			GuildID:         i.GuildID,
-			UserID:          targetUser.ID,
-			MessageCount:    0,
-			Xp:              change.After.CurrentXp,
-			TotalXp:         change.After.TotalXp,
-			LevelXp:         change.After.NextLevelXp,
-			Level:           change.After.Level,
-			Rank:            0,
-			NoXp:            false,
-			MessageLastSent: 0,
-		}, i.GuildID)
-		if createErr != nil {
-			sentry.CaptureException(createErr)
-			editXpAdjustmentError(s, i, "XP Update Failed", "I couldn't create leaderboard data for that member.")
-			return
-		}
-	} else {
-		err = controller.UpdateUserXpState(
-			targetUser.ID,
-			change.After.Level,
-			change.After.CurrentXp,
-			change.After.TotalXp,
-			change.After.NextLevelXp,
-			i.GuildID,
-		)
-		if err != nil {
-			sentry.CaptureException(err)
-			editXpAdjustmentError(s, i, "XP Update Failed", "I couldn't update leaderboard data right now. Try again later.")
-			return
-		}
-	}
-
-	leveling.SyncRoleRewards(s, i.GuildID, targetUser.ID, controller, change.After.Level)
-
-	editXpAdjustmentEmbed(s, i, buildXpAdjustmentEmbed(i, targetUser, change, !userExists, remove))
+	editXpAdjustmentEmbed(s, i, buildXpAdjustmentEmbed(i, targetUser, change, false, remove))
 }
 
 func xpAdjustmentOptions(s *discordgo.Session, i *discordgo.InteractionCreate) (*discordgo.User, int, error) {

--- a/controllers/levels/leaderboardController.go
+++ b/controllers/levels/leaderboardController.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -15,6 +17,14 @@ import (
 )
 
 type LeaderboardController struct{}
+
+type UserStats struct {
+	Level        int
+	CurrentXp    int
+	TotalXp      int
+	MessageCount int
+	NoXp         bool
+}
 
 type LeaderboardPage struct {
 	TotalCount int                      `json:"totalCount"`
@@ -47,6 +57,89 @@ func (c *LeaderboardController) FindUser(id string, guildId string) (map[string]
 	var result map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	return result, err
+}
+
+func (c *LeaderboardController) FindUserStats(id, guildID string) (*UserStats, bool, error) {
+	user, err := c.FindUser(id, guildID)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	stats, err := parseUserStats(user)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return stats, true, nil
+}
+
+func parseUserStats(user map[string]interface{}) (*UserStats, error) {
+	level, err := leaderboardInt(user, "level")
+	if err != nil {
+		return nil, err
+	}
+
+	currentXp, err := leaderboardInt(user, "xp")
+	if err != nil {
+		return nil, err
+	}
+
+	totalXp, err := leaderboardInt(user, "totalXp")
+	if err != nil {
+		return nil, err
+	}
+
+	messageCount, err := leaderboardInt(user, "messageCount")
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserStats{
+		Level:        level,
+		CurrentXp:    currentXp,
+		TotalXp:      totalXp,
+		MessageCount: messageCount,
+		NoXp:         leaderboardOptionalBool(user["noXp"]),
+	}, nil
+}
+
+func leaderboardInt(user map[string]interface{}, key string) (int, error) {
+	value, ok := user[key]
+	if !ok || value == nil {
+		return 0, fmt.Errorf("leaderboard field %q missing", key)
+	}
+
+	switch v := value.(type) {
+	case float64:
+		return int(v), nil
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("leaderboard field %q is not numeric: %w", key, err)
+		}
+		return i, nil
+	default:
+		return 0, fmt.Errorf("leaderboard field %q has unsupported type %T", key, value)
+	}
+}
+
+func leaderboardOptionalBool(value interface{}) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		parsed, err := strconv.ParseBool(v)
+		return err == nil && parsed
+	default:
+		return false
+	}
 }
 
 func (c *LeaderboardController) FindLeaderboardUsers(guildId string, offset, limit int) (*LeaderboardPage, error) {

--- a/controllers/levels/leaderboardController_test.go
+++ b/controllers/levels/leaderboardController_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseUserStats(t *testing.T) {
+	stats, err := parseUserStats(map[string]interface{}{
+		"level":        float64(3),
+		"xp":           "45",
+		"totalXp":      int64(1445),
+		"messageCount": 27,
+		"noXp":         "true",
+	})
+	if err != nil {
+		t.Fatalf("parseUserStats returned an error: %v", err)
+	}
+
+	if stats.Level != 3 || stats.CurrentXp != 45 || stats.TotalXp != 1445 || stats.MessageCount != 27 || !stats.NoXp {
+		t.Fatalf("parseUserStats returned unexpected stats: %+v", stats)
+	}
+}
+
+func TestParseUserStatsRequiresProgressFields(t *testing.T) {
+	_, err := parseUserStats(map[string]interface{}{
+		"level":        1,
+		"xp":           2,
+		"messageCount": 3,
+	})
+	if err == nil {
+		t.Fatal("parseUserStats returned no error for a missing totalXp field")
+	}
+	if !strings.Contains(err.Error(), `"totalXp"`) {
+		t.Fatalf("parseUserStats error did not identify totalXp: %v", err)
+	}
+}

--- a/cron-jobs/quiz/quiz.go
+++ b/cron-jobs/quiz/quiz.go
@@ -7,12 +7,35 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/the-pilot-club/tpcgo"
 
+	controllers "tpc-discord-bot/controllers/levels"
 	"tpc-discord-bot/internal/config"
+	"tpc-discord-bot/internal/leveling"
 	tpcclient "tpc-discord-bot/internal/tpc"
 )
 
 const quizChannelName = "Quiz Channel"
+const quizCorrectXp = 25
+
+type quizAnswerClient interface {
+	GetCurrentQuizQuestions() (*tpcgo.QuizQuestion, error)
+	GetQuizUserResponses(id, answer string) ([]*tpcgo.QuizUserResponse, error)
+	ResetQuizUserResponses() (bool, error)
+}
+
+type quizAnswerDiscord interface {
+	GuildMember(guildID, userID string, options ...discordgo.RequestOption) (*discordgo.Member, error)
+	ChannelMessageSend(channelID, content string, options ...discordgo.RequestOption) (*discordgo.Message, error)
+}
+
+type quizAnswerDependencies struct {
+	quizClient    quizAnswerClient
+	discord       quizAnswerDiscord
+	guildIDs      []string
+	quizChannelID func(guildID string) string
+	awardXp       func(guildID, userID string, amount int) error
+}
 
 // SendQuizQuestion posts the question to the quiz channel in each configured guild.
 func SendQuizQuestion(s *discordgo.Session) error {
@@ -79,7 +102,23 @@ func SendQuizAnswer(s *discordgo.Session) error {
 		return errors.New("tpc session unavailable")
 	}
 
-	q, err := tpc.GetCurrentQuizQuestions()
+	controller := &controllers.LeaderboardController{}
+	return sendQuizAnswer(quizAnswerDependencies{
+		quizClient: tpc,
+		discord:    s,
+		guildIDs:   config.AllGuildIDs(),
+		quizChannelID: func(guildID string) string {
+			return config.GetChannelId(guildID, quizChannelName)
+		},
+		awardXp: func(guildID, userID string, amount int) error {
+			_, err := leveling.AwardXp(s, controller, guildID, userID, amount)
+			return err
+		},
+	})
+}
+
+func sendQuizAnswer(deps quizAnswerDependencies) error {
+	q, err := deps.quizClient.GetCurrentQuizQuestions()
 	if err != nil || q == nil || q.ID == "" {
 		log.Printf("GetCurrentQuizQuestions failed: %v", err)
 		if err != nil {
@@ -89,7 +128,7 @@ func SendQuizAnswer(s *discordgo.Session) error {
 	}
 
 	ans := strings.ToLower(strings.TrimSpace(q.CorrectAnswer))
-	users, err := tpc.GetQuizUserResponses(q.ID, ans)
+	users, err := deps.quizClient.GetQuizUserResponses(q.ID, ans)
 	if err != nil {
 		log.Printf("GetQuizUserResponses failed (questionID=%s, ans=%q): %v", q.ID, ans, err)
 		return fmt.Errorf("get quiz user responses: %w", err)
@@ -107,37 +146,71 @@ func SendQuizAnswer(s *discordgo.Session) error {
 		header = "<:training_team:895480894901592074> The correct answer is unavailable."
 	}
 
-	buildAnswerText := func() string {
-		text := header
-		if len(users) == 0 {
-			return text + "\n\nNo one got the correct answer today :("
+	winnerIDs := make([]string, 0, len(users))
+	for _, u := range users {
+		if u != nil && u.User != nil && u.User.User != nil && u.User.User.ID != "" {
+			winnerIDs = append(winnerIDs, u.User.User.ID)
 		}
-		text += "\n\nThe following members were correct:\n"
-		for _, u := range users {
-			if u != nil && u.User != nil && u.User.User != nil {
-				text += "- <@" + u.User.User.ID + ">\n"
-			}
-		}
-		return text
 	}
-
-	answerText := buildAnswerText()
+	answerText := buildAnswerText(header, winnerIDs)
 
 	var errs []error
-	for _, guildID := range config.AllGuildIDs() {
-		channelID := config.GetChannelId(guildID, quizChannelName)
+	for _, guildID := range deps.guildIDs {
+		for _, userID := range winnerIDs {
+			member, err := deps.discord.GuildMember(guildID, userID)
+			if err != nil {
+				if quizMemberNotFound(err) {
+					continue
+				}
+
+				log.Printf("failed to verify quiz winner %s in guild %s: %v", userID, guildID, err)
+				errs = append(errs, fmt.Errorf("verify quiz winner %s in guild %s: %w", userID, guildID, err))
+				continue
+			}
+			if member == nil {
+				continue
+			}
+
+			if err := deps.awardXp(guildID, userID, quizCorrectXp); err != nil {
+				log.Printf("failed to award quiz XP to user %s in guild %s: %v", userID, guildID, err)
+				errs = append(errs, fmt.Errorf("award quiz XP to user %s in guild %s: %w", userID, guildID, err))
+			}
+		}
+
+		channelID := deps.quizChannelID(guildID)
 		if channelID == "" {
 			continue
 		}
-		if _, err := s.ChannelMessageSend(channelID, answerText); err != nil {
+		if _, err := deps.discord.ChannelMessageSend(channelID, answerText); err != nil {
 			log.Printf("failed to send quiz answer to guild %s: %v", guildID, err)
 			errs = append(errs, fmt.Errorf("send quiz answer to guild %s: %w", guildID, err))
 		}
 	}
 
-	if _, err := tpc.ResetQuizUserResponses(); err != nil {
+	if _, err := deps.quizClient.ResetQuizUserResponses(); err != nil {
 		log.Printf("ResetQuizUserResponses error: %v", err)
 		errs = append(errs, fmt.Errorf("reset quiz user responses: %w", err))
 	}
 	return errors.Join(errs...)
+}
+
+func buildAnswerText(header string, winnerIDs []string) string {
+	if len(winnerIDs) == 0 {
+		return header + "\n\nNo one got the correct answer today :("
+	}
+
+	var text strings.Builder
+	text.WriteString(header)
+	text.WriteString("\n\nThe following members were correct:\n")
+	for _, userID := range winnerIDs {
+		fmt.Fprintf(&text, "- <@%s> (+%d XP)\n", userID, quizCorrectXp)
+	}
+	return text.String()
+}
+
+func quizMemberNotFound(err error) bool {
+	var restErr *discordgo.RESTError
+	return errors.As(err, &restErr) &&
+		restErr.Message != nil &&
+		restErr.Message.Code == discordgo.ErrCodeUnknownMember
 }

--- a/cron-jobs/quiz/quiz_test.go
+++ b/cron-jobs/quiz/quiz_test.go
@@ -1,0 +1,309 @@
+package quiz
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/the-pilot-club/tpcgo"
+)
+
+type fakeQuizAnswerClient struct {
+	question           *tpcgo.QuizQuestion
+	questionErr        error
+	responses          []*tpcgo.QuizUserResponse
+	responsesErr       error
+	responseQuestionID string
+	responseAnswer     string
+	resetErr           error
+	resetCalls         int
+}
+
+func (f *fakeQuizAnswerClient) GetCurrentQuizQuestions() (*tpcgo.QuizQuestion, error) {
+	return f.question, f.questionErr
+}
+
+func (f *fakeQuizAnswerClient) GetQuizUserResponses(id, answer string) ([]*tpcgo.QuizUserResponse, error) {
+	f.responseQuestionID = id
+	f.responseAnswer = answer
+	return f.responses, f.responsesErr
+}
+
+func (f *fakeQuizAnswerClient) ResetQuizUserResponses() (bool, error) {
+	f.resetCalls++
+	return f.resetErr == nil, f.resetErr
+}
+
+type quizMemberResult struct {
+	member *discordgo.Member
+	err    error
+}
+
+type sentQuizMessage struct {
+	channelID string
+	content   string
+}
+
+type fakeQuizAnswerDiscord struct {
+	members     map[string]quizMemberResult
+	memberCalls []string
+	sendErrs    map[string]error
+	messages    []sentQuizMessage
+}
+
+func (f *fakeQuizAnswerDiscord) GuildMember(guildID, userID string, _ ...discordgo.RequestOption) (*discordgo.Member, error) {
+	key := guildID + "/" + userID
+	f.memberCalls = append(f.memberCalls, key)
+	result := f.members[key]
+	return result.member, result.err
+}
+
+func (f *fakeQuizAnswerDiscord) ChannelMessageSend(channelID, content string, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	f.messages = append(f.messages, sentQuizMessage{channelID: channelID, content: content})
+	if err := f.sendErrs[channelID]; err != nil {
+		return nil, err
+	}
+	return &discordgo.Message{ID: "message-" + channelID}, nil
+}
+
+type quizAwardCall struct {
+	guildID string
+	userID  string
+	amount  int
+}
+
+func quizResponse(userID string) *tpcgo.QuizUserResponse {
+	return &tpcgo.QuizUserResponse{
+		User: &discordgo.Member{User: &discordgo.User{ID: userID}},
+	}
+}
+
+func unknownMemberError() error {
+	return &discordgo.RESTError{
+		Message: &discordgo.APIErrorMessage{Code: discordgo.ErrCodeUnknownMember},
+	}
+}
+
+func TestBuildAnswerTextIncludesQuizXp(t *testing.T) {
+	got := buildAnswerText("The correct answer is A", []string{"user-1", "user-2"})
+	want := "The correct answer is A\n\nThe following members were correct:\n" +
+		"- <@user-1> (+25 XP)\n" +
+		"- <@user-2> (+25 XP)\n"
+
+	if got != want {
+		t.Fatalf("buildAnswerText() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildAnswerTextWithNoWinners(t *testing.T) {
+	got := buildAnswerText("The correct answer is A", nil)
+	want := "The correct answer is A\n\nNo one got the correct answer today :("
+
+	if got != want {
+		t.Fatalf("buildAnswerText() = %q, want %q", got, want)
+	}
+}
+
+func TestQuizMemberNotFound(t *testing.T) {
+	notFound := unknownMemberError()
+	if !quizMemberNotFound(notFound) {
+		t.Fatal("quizMemberNotFound returned false for Discord's unknown-member error")
+	}
+
+	if quizMemberNotFound(errors.New("temporary Discord failure")) {
+		t.Fatal("quizMemberNotFound returned true for an unrelated error")
+	}
+}
+
+func TestSendQuizAnswerAwardsMembersAcrossGuildsOffline(t *testing.T) {
+	quizClient := &fakeQuizAnswerClient{
+		question: &tpcgo.QuizQuestion{
+			ID:            "question-1",
+			CorrectAnswer: "A",
+			OptionA:       "Answer A",
+		},
+		responses: []*tpcgo.QuizUserResponse{
+			quizResponse("user-1"),
+			quizResponse("user-2"),
+		},
+	}
+	discord := &fakeQuizAnswerDiscord{
+		members: map[string]quizMemberResult{
+			"guild-1/user-1": {member: &discordgo.Member{User: &discordgo.User{ID: "user-1"}}},
+			"guild-1/user-2": {err: unknownMemberError()},
+			"guild-2/user-1": {},
+			"guild-2/user-2": {member: &discordgo.Member{User: &discordgo.User{ID: "user-2"}}},
+		},
+	}
+	var awards []quizAwardCall
+
+	err := sendQuizAnswer(quizAnswerDependencies{
+		quizClient: quizClient,
+		discord:    discord,
+		guildIDs:   []string{"guild-1", "guild-2"},
+		quizChannelID: func(guildID string) string {
+			return "channel-" + guildID
+		},
+		awardXp: func(guildID, userID string, amount int) error {
+			awards = append(awards, quizAwardCall{guildID: guildID, userID: userID, amount: amount})
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("sendQuizAnswer returned an error: %v", err)
+	}
+
+	wantAwards := []quizAwardCall{
+		{guildID: "guild-1", userID: "user-1", amount: 25},
+		{guildID: "guild-2", userID: "user-2", amount: 25},
+	}
+	if !reflect.DeepEqual(awards, wantAwards) {
+		t.Fatalf("awards = %+v, want %+v", awards, wantAwards)
+	}
+	wantMemberCalls := []string{
+		"guild-1/user-1",
+		"guild-1/user-2",
+		"guild-2/user-1",
+		"guild-2/user-2",
+	}
+	if !reflect.DeepEqual(discord.memberCalls, wantMemberCalls) {
+		t.Fatalf("member calls = %v, want %v", discord.memberCalls, wantMemberCalls)
+	}
+	if len(discord.messages) != 2 {
+		t.Fatalf("sent %d messages, want 2", len(discord.messages))
+	}
+	for _, message := range discord.messages {
+		wantContent := buildAnswerText(
+			"<:training_team:895480894901592074> The correct answer is ||🇦 Answer A||",
+			[]string{"user-1", "user-2"},
+		)
+		if message.content != wantContent {
+			t.Fatalf("message content = %q, want %q", message.content, wantContent)
+		}
+	}
+	if quizClient.responseQuestionID != "question-1" || quizClient.responseAnswer != "a" {
+		t.Fatalf("response query = (%q, %q), want (question-1, a)", quizClient.responseQuestionID, quizClient.responseAnswer)
+	}
+	if quizClient.resetCalls != 1 {
+		t.Fatalf("reset calls = %d, want 1", quizClient.resetCalls)
+	}
+}
+
+func TestSendQuizAnswerContinuesAndResetsAfterPerGuildFailures(t *testing.T) {
+	membershipErr := errors.New("membership failed")
+	awardErr := errors.New("award failed")
+	sendErr := errors.New("send failed")
+	resetErr := errors.New("reset failed")
+	quizClient := &fakeQuizAnswerClient{
+		question: &tpcgo.QuizQuestion{ID: "question-1", CorrectAnswer: "B", OptionB: "Answer B"},
+		responses: []*tpcgo.QuizUserResponse{
+			quizResponse("user-1"),
+			quizResponse("user-2"),
+			quizResponse("user-3"),
+		},
+		resetErr: resetErr,
+	}
+	discord := &fakeQuizAnswerDiscord{
+		members: map[string]quizMemberResult{
+			"guild-1/user-1": {err: membershipErr},
+			"guild-1/user-2": {member: &discordgo.Member{User: &discordgo.User{ID: "user-2"}}},
+			"guild-1/user-3": {member: &discordgo.Member{User: &discordgo.User{ID: "user-3"}}},
+		},
+		sendErrs: map[string]error{"channel-1": sendErr},
+	}
+	var awards []quizAwardCall
+
+	err := sendQuizAnswer(quizAnswerDependencies{
+		quizClient: quizClient,
+		discord:    discord,
+		guildIDs:   []string{"guild-1"},
+		quizChannelID: func(string) string {
+			return "channel-1"
+		},
+		awardXp: func(guildID, userID string, amount int) error {
+			awards = append(awards, quizAwardCall{guildID: guildID, userID: userID, amount: amount})
+			if userID == "user-2" {
+				return awardErr
+			}
+			return nil
+		},
+	})
+
+	for _, wantErr := range []error{membershipErr, awardErr, sendErr, resetErr} {
+		if !errors.Is(err, wantErr) {
+			t.Errorf("sendQuizAnswer error %v does not contain %v", err, wantErr)
+		}
+	}
+	wantAwards := []quizAwardCall{
+		{guildID: "guild-1", userID: "user-2", amount: 25},
+		{guildID: "guild-1", userID: "user-3", amount: 25},
+	}
+	if !reflect.DeepEqual(awards, wantAwards) {
+		t.Fatalf("awards = %+v, want %+v", awards, wantAwards)
+	}
+	if len(discord.messages) != 1 {
+		t.Fatalf("message attempts = %d, want 1", len(discord.messages))
+	}
+	if quizClient.resetCalls != 1 {
+		t.Fatalf("reset calls = %d, want 1", quizClient.resetCalls)
+	}
+}
+
+func TestSendQuizAnswerStopsBeforeResetOnRetrievalFailure(t *testing.T) {
+	questionErr := errors.New("question failed")
+	responsesErr := errors.New("responses failed")
+
+	tests := []struct {
+		name     string
+		client   *fakeQuizAnswerClient
+		wantErr  error
+		wantText string
+	}{
+		{
+			name:    "question error",
+			client:  &fakeQuizAnswerClient{questionErr: questionErr},
+			wantErr: questionErr,
+		},
+		{
+			name:     "question unavailable",
+			client:   &fakeQuizAnswerClient{},
+			wantText: "current quiz question unavailable",
+		},
+		{
+			name: "responses error",
+			client: &fakeQuizAnswerClient{
+				question:     &tpcgo.QuizQuestion{ID: "question-1", CorrectAnswer: "A"},
+				responsesErr: responsesErr,
+			},
+			wantErr: responsesErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discord := &fakeQuizAnswerDiscord{}
+			err := sendQuizAnswer(quizAnswerDependencies{
+				quizClient: tt.client,
+				discord:    discord,
+				quizChannelID: func(string) string {
+					return "channel-1"
+				},
+				awardXp: func(string, string, int) error { return nil },
+			})
+
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("sendQuizAnswer error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantText != "" && (err == nil || err.Error() != tt.wantText) {
+				t.Fatalf("sendQuizAnswer error = %v, want %q", err, tt.wantText)
+			}
+			if tt.client.resetCalls != 0 {
+				t.Fatalf("reset calls = %d, want 0", tt.client.resetCalls)
+			}
+			if len(discord.messages) != 0 {
+				t.Fatalf("message attempts = %d, want 0", len(discord.messages))
+			}
+		})
+	}
+}

--- a/internal/leveling/leveling.go
+++ b/internal/leveling/leveling.go
@@ -27,6 +27,62 @@ type UserProgressChange struct {
 	AppliedDelta   int
 }
 
+type leaderboardXpStore interface {
+	FindUserStats(id, guildID string) (*controllers.UserStats, bool, error)
+	CreateUserRecord(data controllers.UserCreate, guildID string) error
+	UpdateUserXpState(id string, level, xp, totalXp, levelXp int, guildID string) error
+}
+
+func AwardXp(s *discordgo.Session, controller *controllers.LeaderboardController, guildID, userID string, amount int) (UserProgressChange, error) {
+	return awardXp(controller, guildID, userID, amount, func(newLevel int) {
+		SyncRoleRewards(s, guildID, userID, controller, newLevel)
+	})
+}
+
+func awardXp(store leaderboardXpStore, guildID, userID string, amount int, syncRoleRewards func(newLevel int)) (UserProgressChange, error) {
+	stats, found, err := store.FindUserStats(userID, guildID)
+	if err != nil {
+		return UserProgressChange{}, err
+	}
+
+	if stats == nil {
+		stats = &controllers.UserStats{}
+	}
+
+	change := ApplyXpDelta(stats.Level, stats.CurrentXp, stats.TotalXp, amount)
+	if !found {
+		err = store.CreateUserRecord(controllers.UserCreate{
+			GuildID:         guildID,
+			UserID:          userID,
+			MessageCount:    0,
+			Xp:              change.After.CurrentXp,
+			TotalXp:         change.After.TotalXp,
+			LevelXp:         change.After.NextLevelXp,
+			Level:           change.After.Level,
+			Rank:            0,
+			NoXp:            false,
+			MessageLastSent: 0,
+		}, guildID)
+	} else {
+		err = store.UpdateUserXpState(
+			userID,
+			change.After.Level,
+			change.After.CurrentXp,
+			change.After.TotalXp,
+			change.After.NextLevelXp,
+			guildID,
+		)
+	}
+	if err != nil {
+		return UserProgressChange{}, err
+	}
+
+	if syncRoleRewards != nil {
+		syncRoleRewards(change.After.Level)
+	}
+	return change, nil
+}
+
 func TotalXpForLevel(level int) int {
 	if level <= 0 {
 		return 0

--- a/internal/leveling/leveling_test.go
+++ b/internal/leveling/leveling_test.go
@@ -1,0 +1,194 @@
+package leveling
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	controllers "tpc-discord-bot/controllers/levels"
+)
+
+type xpUpdateCall struct {
+	userID  string
+	level   int
+	xp      int
+	totalXp int
+	levelXp int
+	guildID string
+}
+
+type fakeLeaderboardXpStore struct {
+	stats       *controllers.UserStats
+	found       bool
+	findErr     error
+	createErr   error
+	updateErr   error
+	created     *controllers.UserCreate
+	createGuild string
+	updates     []xpUpdateCall
+}
+
+func (f *fakeLeaderboardXpStore) FindUserStats(_, _ string) (*controllers.UserStats, bool, error) {
+	return f.stats, f.found, f.findErr
+}
+
+func (f *fakeLeaderboardXpStore) CreateUserRecord(data controllers.UserCreate, guildID string) error {
+	f.created = &data
+	f.createGuild = guildID
+	return f.createErr
+}
+
+func (f *fakeLeaderboardXpStore) UpdateUserXpState(userID string, level, xp, totalXp, levelXp int, guildID string) error {
+	f.updates = append(f.updates, xpUpdateCall{
+		userID:  userID,
+		level:   level,
+		xp:      xp,
+		totalXp: totalXp,
+		levelXp: levelXp,
+		guildID: guildID,
+	})
+	return f.updateErr
+}
+
+func TestAwardXpUpdatesExistingUserAndSyncsLevel(t *testing.T) {
+	store := &fakeLeaderboardXpStore{
+		stats: &controllers.UserStats{
+			Level:     0,
+			CurrentXp: 90,
+			TotalXp:   90,
+		},
+		found: true,
+	}
+	var syncedLevels []int
+
+	change, err := awardXp(store, "guild-1", "user-1", 25, func(level int) {
+		syncedLevels = append(syncedLevels, level)
+	})
+	if err != nil {
+		t.Fatalf("awardXp returned an error: %v", err)
+	}
+
+	if change.AppliedDelta != 25 || change.After.Level != 1 || change.After.CurrentXp != 15 || change.After.TotalXp != 115 || change.After.NextLevelXp != 400 {
+		t.Fatalf("awardXp returned an unexpected change: %+v", change)
+	}
+
+	wantUpdate := []xpUpdateCall{{
+		userID:  "user-1",
+		level:   1,
+		xp:      15,
+		totalXp: 115,
+		levelXp: 400,
+		guildID: "guild-1",
+	}}
+	if !reflect.DeepEqual(store.updates, wantUpdate) {
+		t.Fatalf("updates = %+v, want %+v", store.updates, wantUpdate)
+	}
+	if store.created != nil {
+		t.Fatalf("awardXp created a record for an existing user: %+v", store.created)
+	}
+	if !reflect.DeepEqual(syncedLevels, []int{1}) {
+		t.Fatalf("synced levels = %v, want [1]", syncedLevels)
+	}
+}
+
+func TestAwardXpCreatesMissingUser(t *testing.T) {
+	store := &fakeLeaderboardXpStore{}
+	var syncedLevels []int
+
+	change, err := awardXp(store, "guild-1", "user-1", 25, func(level int) {
+		syncedLevels = append(syncedLevels, level)
+	})
+	if err != nil {
+		t.Fatalf("awardXp returned an error: %v", err)
+	}
+
+	wantCreate := &controllers.UserCreate{
+		GuildID:         "guild-1",
+		UserID:          "user-1",
+		MessageCount:    0,
+		Xp:              25,
+		TotalXp:         25,
+		LevelXp:         100,
+		Level:           0,
+		Rank:            0,
+		NoXp:            false,
+		MessageLastSent: 0,
+	}
+	if !reflect.DeepEqual(store.created, wantCreate) {
+		t.Fatalf("created record = %+v, want %+v", store.created, wantCreate)
+	}
+	if store.createGuild != "guild-1" {
+		t.Fatalf("create guild = %q, want guild-1", store.createGuild)
+	}
+	if len(store.updates) != 0 {
+		t.Fatalf("awardXp updated a missing user: %+v", store.updates)
+	}
+	if change.AppliedDelta != 25 || change.After.TotalXp != 25 {
+		t.Fatalf("awardXp returned an unexpected change: %+v", change)
+	}
+	if !reflect.DeepEqual(syncedLevels, []int{0}) {
+		t.Fatalf("synced levels = %v, want [0]", syncedLevels)
+	}
+}
+
+func TestAwardXpClampsRemovalAtZero(t *testing.T) {
+	store := &fakeLeaderboardXpStore{
+		stats: &controllers.UserStats{CurrentXp: 10, TotalXp: 10},
+		found: true,
+	}
+
+	change, err := awardXp(store, "guild-1", "user-1", -25, nil)
+	if err != nil {
+		t.Fatalf("awardXp returned an error: %v", err)
+	}
+	if change.AppliedDelta != -10 || change.After.TotalXp != 0 || change.After.CurrentXp != 0 {
+		t.Fatalf("awardXp returned an unexpected clamped change: %+v", change)
+	}
+}
+
+func TestAwardXpDoesNotSyncAfterPersistenceFailure(t *testing.T) {
+	fetchErr := errors.New("fetch failed")
+	createErr := errors.New("create failed")
+	updateErr := errors.New("update failed")
+
+	tests := []struct {
+		name    string
+		store   *fakeLeaderboardXpStore
+		wantErr error
+	}{
+		{
+			name:    "fetch",
+			store:   &fakeLeaderboardXpStore{findErr: fetchErr},
+			wantErr: fetchErr,
+		},
+		{
+			name:    "create",
+			store:   &fakeLeaderboardXpStore{createErr: createErr},
+			wantErr: createErr,
+		},
+		{
+			name: "update",
+			store: &fakeLeaderboardXpStore{
+				stats:     &controllers.UserStats{},
+				found:     true,
+				updateErr: updateErr,
+			},
+			wantErr: updateErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncCalls := 0
+			_, err := awardXp(tt.store, "guild-1", "user-1", 25, func(int) {
+				syncCalls++
+			})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("awardXp error = %v, want %v", err, tt.wantErr)
+			}
+			if syncCalls != 0 {
+				t.Fatalf("role sync called %d times after failure", syncCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  Awards 25 XP to members who answer the daily aviation quiz correctly.

  Closes the-pilot-club/issues-and-new-features#28

  ## Changes

  - Awards each correct respondent 25 XP.
  - Verifies that a winner belongs to a configured guild before awarding XP there.
  - Creates a leaderboard record when a winner does not already have one.
  - Synchronizes level-based role rewards after awarding XP.
  - Adds `(+25 XP)` to winner lines in the answer reveal.
  - Extracts a shared XP-award path used by both the quiz job and `/givexp`.
  - Continues processing other winners and guilds when an individual operation fails.
  - Keeps the existing `tpcgo` quiz integration and Core API leaderboard controller.

  ## Testing

 Behaviour tested w/o contacting prod:

  - `go test ./...`
  - `go build ./...`
  - `go test -race ./internal/leveling ./cron-jobs/quiz`
  - `go vet ./controllers/levels ./internal/leveling ./commands/general ./cron-jobs/quiz`

Tests cover new and existing leaderboard records, level-ups, membership gating, partial failures, answer messages, and quiz-response resets.
